### PR TITLE
Make logic more readable when to treat an extractor as a metadata extractor

### DIFF
--- a/pipelines/whale/__init__.py
+++ b/pipelines/whale/__init__.py
@@ -164,7 +164,6 @@ def pull():
         conf.put(manifest_key, tmp_manifest_path)
 
         for i, extractor in enumerate(extractors):
-            is_metadata_extractor = i == 0
             task = WhaleTask(
                 extractor=extractor,
                 loader=WhaleLoader(),
@@ -173,7 +172,8 @@ def pull():
 
             # Enable try except for non-metadata extractors
             # No need to update the manifest for other extractors
-            if is_metadata_extractor:
+
+            if conf.get_bool(f"{extractor.get_scope()}.is_metadata_extractor", True):
                 task.run()
                 task.save_stats()
                 conf.pop(manifest_key)

--- a/pipelines/whale/utils/extractor_wrappers.py
+++ b/pipelines/whale/utils/extractor_wrappers.py
@@ -48,6 +48,8 @@ def add_ugc_runner(extractors: list, conf: ConfigTree, connection):
         f"{METRIC_RUNNER_SCOPE}.{SQL_ALCHEMY_ENGINE_SCOPE}.{SQLAlchemyEngine.CREDENTIALS_PATH_KEY}",
         connection.key_path,
     )
+    conf.put(f"{METRIC_RUNNER_SCOPE}.is_metadata_extractor", False)
+
     extractors.append(UGCRunner())
     return extractors, conf
 
@@ -73,6 +75,7 @@ def configure_bigquery_extractors(connection: ConnectionConfigSchema):
             f"{watermark_scope}.project_id": connection.project_id,
             f"{watermark_scope}.project_credentials": connection.project_credentials,
             f"{watermark_scope}.included_tables_regex": connection.included_tables_regex,
+            f"{watermark_scope}.is_metadata_extractor": False,
         }
     )
 
@@ -159,6 +162,7 @@ def configure_presto_extractors(connection: ConnectionConfigSchema):
             f"{loop_scope}.{LoopExtractor.IS_ANALYZE_ENABLED_KEY}": False,
             f"{loop_scope}.{LoopExtractor.DATABASE_KEY}": connection.name,
             f"{loop_scope}.{LoopExtractor.CLUSTER_KEY}": connection.cluster,
+            f"{loop_scope}.is_metadata_extractor": False,
             f"{scope}.{Extractor.DATABASE_KEY}": connection.name,
             f"{scope}.{Extractor.CLUSTER_KEY}": connection.cluster,
             f"{scope}.{Extractor.WHERE_CLAUSE_SUFFIX_KEY}": connection.where_clause_suffix,


### PR DESCRIPTION
The extractors that are not considered metadata extractors I think are:
- BigQuery Watermark extractor
- Presto Loop extractor
- the Metric Runner

Is this correct or did I miss one?